### PR TITLE
Fix join community not working from communities list

### DIFF
--- a/src/js/directives/participate.js
+++ b/src/js/directives/participate.js
@@ -19,7 +19,7 @@ angular.module('Teem')
               CommunitiesSvc.find($scope.community.id).then(function(community) {
                 $timeout(function() {
                   community.toggleParticipant();
-                  angular.extend($scope.community, community);
+                  $scope.community.participants = community.participants;
                 });
               });
             }

--- a/src/js/directives/participate.js
+++ b/src/js/directives/participate.js
@@ -4,16 +4,27 @@ angular.module('Teem')
   .directive('participate', function() {
     return {
       controller: [
-      '$scope', '$element', '$attrs', 'SessionSvc', '$timeout',
-      function($scope, $element, $attrs, SessionSvc, $timeout) {
+      '$scope', '$element', '$attrs', 'SessionSvc', '$timeout', 'CommunitiesSvc',
+      function($scope, $element, $attrs, SessionSvc, $timeout, CommunitiesSvc) {
         $scope.participateCopyOn  = $attrs.participateCopyOn;
         $scope.participateCopyOff = $attrs.participateCopyOff;
-
-        $element.on('click', function() {
+        
+        $element.on('click', function($event) {
           SessionSvc.loginRequired($scope, function() {
-            $scope.community.toggleParticipant();
-            $timeout();
+            if ($scope.community.toggleParticipant) {
+              $timeout(function() {
+                $scope.community.toggleParticipant();
+              });
+            } else {
+              CommunitiesSvc.find($scope.community.id).then(function(community) {
+                $timeout(function() {
+                  community.toggleParticipant();
+                  angular.extend($scope.community, community);
+                });
+              });
+            }
           });
+          $event.stopPropagation();
         });
       }],
       templateUrl: 'participate.html'


### PR DESCRIPTION
Issue #171 occurs because the communities list is read-only and because of more than one click event triggering. This makes participate get a writable copy of a community if it received a read-only one. Also, it makes the user stay on the list after joining a community.